### PR TITLE
Get summonerName without TagLine

### DIFF
--- a/leagueofevents/leagueofevents.py
+++ b/leagueofevents/leagueofevents.py
@@ -7,7 +7,7 @@ class Player:
     def __init__(self, game_data):
         self.game_data = game_data
 
-        self.summoner_name = self.game_data["activePlayer"]["summonerName"]
+        self.summoner_name = self.game_data["activePlayer"]["summonerName"].split("#")[0]
         self.abilities = self._load_abilities()
         self.score = self._load_score()
         self.champion = self._load_champion_stats()


### PR DESCRIPTION
#1

I've made changes to  the issue.

Due to restrictions on Riot accounts, they can't contain '#' symbols in username. Therefore, the summoner name will now consist of the name before the '#'.